### PR TITLE
DO NOT MERGE - Issues 1545, 163: Update error handling on availability API

### DIFF
--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -5,8 +5,8 @@ is available as a .gov domain.
 
 <script>
     function checkDomainAvailability() {
-        // TODO: update baseUrl to stable when Cloudflare migrates their data 11/15
-        const baseUrl = "https://manage.get.gov/api/v1/available/?domain="
+        // TODO: update baseUrl to stable before merging
+        const baseUrl = "https://getgov-backup.app.cloud.gov/api/v1/available/?domain="
 
         var requested_domain = document.getElementById('domain-input').value
 
@@ -28,7 +28,7 @@ is available as a .gov domain.
                 <div class="usa-alert usa-alert--success usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                        <b>${requested_domain_display_string}</b> is available!
+                        <b title=${requested_domain_display_string} aria-label=${requested_domain_display_string}>${truncateDomain(requested_domain_display_string)}</b> is available!
                             <a class="usa-link" href="{{ '/domains/before/' | url }}">
                                 Read about next steps to take before requesting your .gov domain.
                             </a>
@@ -37,13 +37,28 @@ is available as a .gov domain.
                 </div>
                 `
                 )
-            } 
-            else {
+            } else if (response.code == "unavailable") {
+                // The unavailable API response contains duplicative language. Omit it and use our hardcoded feedback instead.
                 render_result(`
                 <div class="usa-alert usa-alert--error usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                            <b>${requested_domain_display_string}</b> isn't available.
+                            <b title=${requested_domain_display_string} aria-label=${requested_domain_display_string}>${truncateDomain(requested_domain_display_string)}</b> isn't available.
+                            <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
+                                Read more about choosing your .gov domain.
+                            </a>
+                        </p>
+                    </div>
+                </div>
+                `
+                )
+            } else {
+                // The error API response contains copy that complements our harcoded feedback.
+                render_result(`
+                <div class="usa-alert usa-alert--error usa-alert--slim" role="alert">
+                    <div class="usa-alert__body">
+                        <p class="usa-alert__text">
+                            <b title=${requested_domain_display_string} aria-label=${requested_domain_display_string}>${truncateDomain(requested_domain_display_string)}</b> isn't available.
                             ${response.message} 
                             <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
                                 Read more about choosing your .gov domain.
@@ -61,6 +76,15 @@ is available as a .gov domain.
 
     function render_result(content, append = true){
       document.getElementById('domain-available-message').innerHTML = (append == true) ? content : `<div></div>`;
+    }
+
+    function truncateDomain(domain, length = 20, suffix = '....gov') {
+        if (domain.length <= length) {
+            return domain;
+        } else {
+            const truncatedDomain = domain.slice(0, length - suffix.length) + suffix;
+            return truncatedDomain;
+        }
     }
 
     document.addEventListener("keypress", function(event) {

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -5,8 +5,7 @@ is available as a .gov domain.
 
 <script>
     function checkDomainAvailability() {
-        // TODO: update baseUrl to stable before merging
-        const baseUrl = "https://getgov-backup.app.cloud.gov/api/v1/available/?domain="
+        const baseUrl = "https://manage.get.gov/api/v1/available/?domain="
 
         var requested_domain = document.getElementById('domain-input').value
 

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -27,7 +27,7 @@ is available as a .gov domain.
                 <div class="usa-alert usa-alert--success usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                        <b title=${requested_domain_display_string} aria-label=${requested_domain_display_string}>${truncateDomain(requested_domain_display_string)}</b> is available!
+                            That domain is available!
                             <a class="usa-link" href="{{ '/domains/before/' | url }}">
                                 Read about next steps to take before requesting your .gov domain.
                             </a>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -37,32 +37,12 @@ is available as a .gov domain.
                 </div>
                 `
                 )
-            } else if (response.code == "unavailable") {
-                // The unavailable API response contains duplicative language. Omit it and use our hardcoded feedback instead.
-                render_result(`
-                <div class="usa-alert usa-alert--error usa-alert--slim" role="alert">
-                    <div class="usa-alert__body">
-                        <p class="usa-alert__text">
-                            <b title=${requested_domain_display_string} aria-label=${requested_domain_display_string}>${truncateDomain(requested_domain_display_string)}</b> isn't available.
-                            <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
-                                Read more about choosing your .gov domain.
-                            </a>
-                        </p>
-                    </div>
-                </div>
-                `
-                )
             } else {
-                // The error API response contains copy that complements our hardcoded feedback.
                 render_result(`
                 <div class="usa-alert usa-alert--error usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                            <b title=${requested_domain_display_string} aria-label=${requested_domain_display_string}>${truncateDomain(requested_domain_display_string)}</b> isn't available.
                             ${response.message} 
-                            <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
-                                Read more about choosing your .gov domain.
-                            </a>
                         </p>
                     </div>
                 </div>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -53,7 +53,7 @@ is available as a .gov domain.
                 `
                 )
             } else {
-                // The error API response contains copy that complements our harcoded feedback.
+                // The error API response contains copy that complements our hardcoded feedback.
                 render_result(`
                 <div class="usa-alert usa-alert--error usa-alert--slim" role="alert">
                     <div class="usa-alert__body">

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -5,7 +5,8 @@ is available as a .gov domain.
 
 <script>
     function checkDomainAvailability() {
-        const baseUrl = "https://manage.get.gov/api/v1/available/?domain="
+        // TODO: update baseUrl to stable before merging
+        const baseUrl = "https://getgov-backup.app.cloud.gov/api/v1/available/?domain="
 
         var requested_domain = document.getElementById('domain-input').value
 


### PR DESCRIPTION
## Ticket

Resolves #163 
Resolves #[1545](https://github.com/cisagov/manage.get.gov/issues/1545)

Also resolves #[1304](https://github.com/cisagov/manage.get.gov/issues/1304)

<!--Reminder, when a code change is made that is user facing, beyond content updates, then the following are required:
- a developer approves the PR
- a designer approves the PR or checks off all relevant items in this checklist.

All other changes require just a single approving review.-->

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Update error handling on availability API, pairs with [PR #1615](https://github.com/cisagov/manage.get.gov/pull/1615) on manage.get.gov 

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR.
--->

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  -->

The preview site will pair with the getgov-backup sandbox that has the updated API code on manage.get.gov. This is a blocker on merging this PR until 1615 is merged.

## Setup

<!--  Add any steps or code to run in this section to help others run your code.
    
    Example 1:
    ```sh
    echo "Code goes here"
    ``` 
    
    Example 2: If the PR was to add a new link with a redirect, this section could simply be:
    -go to /path/to/start/page
    -click the blue link in the <insert location>
    -notice user is redirected to <proper end location>
-->

Enter cisa to test unavailable messaging.
Enter a domain with www or with multiple dots to test that error msg.
Enter a dollar sign.
Enter an available domain.

Review link [here](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/rjm/availability-api/).

## Code Review Verification Steps

### As the original developer, I have

#### Satisfied acceptance criteria and met development standards

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Created/modified automated tests
- [x] Added at least 2 developers as PR reviewers (only 1 will need to approve)
- [x] Messaged on Slack or in standup to notify the team that a PR is ready for review
- [ ] Changes to “how we do things” are documented in READMEs and or onboarding guide
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Original Developer)

- [x] All new functions and methods are commented using plain language
- [ ] Did dependency updates in Pipfile also get changed in requirements.txt?
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values

#### Validated user-facing changes (if applicable)

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)
- [ ] Add at least 1 designer as PR reviewer

### As a code reviewer, I have

#### Reviewed, tested, and left feedback about the changes

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] If any model was updated to modify/add/delete columns, makemigrations was ran and the assoicated migrations file has been commited.

#### Ensured code standards are met (Code reviewer)

- [ ] All new functions and methods are commented using plain language
- [ ] Interactions with external systems are wrapped in try/except
- [ ] Error handling exists for unusual or missing values
- [ ] (Rarely needed) Did dependency updates in Pipfile also get changed in requirements.txt?

#### Validated user-facing changes as a developer

- [ ] New pages have been added to .pa11yci file so that they will be tested with our automated accessibility testing
- [ ] Checked keyboard navigability
- [ ] Meets all designs and user flows provided by design/product
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers, the suggestion is to use ones that the developer didn't (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

**Note:** Multiple code reviewers can share the checklists above, a second reviewers should not make a duplicate checklist

### As a designer reviewer, I have

#### Verified that the changes match the design intention

- [ ] Checked that the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

#### Validated user-facing changes as a designer

- [ ] Checked keyboard navigability
- [ ] Tested general usability, landmarks, page header structure, and links with a screen reader (such as Voiceover or ANDI)

- [ ] Tested with multiple browsers (check off which ones were used)
  - [ ] Chrome
  - [ ] Microsoft Edge
  - [ ] FireFox
  - [ ] Safari

- [ ] (Rarely needed) Tested as both an analyst and applicant user

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use [GIPHY Capture](https://giphy.com/apps/giphycapture) for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
