### PR TITLE
 Remove beta from search URL; add new search access key

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -37,10 +37,10 @@ searchgov:
   endpoint: https://search.usa.gov
 
 #   # Replace this with your search.gov account.
-  affiliate: beta.get.gov
+  affiliate: get.gov
 
 #   # Replace this with your access key.
-  access_key: 1dDc6veg9gSCDz4GbBODf_VBUjxYXWTGB6mQpP4GiCw=
+  access_key: hEUY8jNk7Zcmn7Ni5Tafek-3eapK2RJ8WpeUDHnc_T4=
     #
 #   # This renders the results within the page instead of sending to user to search.gov.
   inline: true


### PR DESCRIPTION
## Changes

<!-- What was added, updated, or removed in this PR. -->
- Remove beta from URL for search.gov
- Add new access key for get.gov (which is our new search.gov site)
