### PR TITLE
Add user-friendly tag to shorten an anchor link for plain text email

### DIFF
--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -32,6 +32,7 @@ We’ll use the information you provide to verify your organization’s eligibil
 
 If you have your Login.gov account and have gathered all the information you need, completing your domain request might take around 15 minutes.
 
+<span id="one-domain-per-service"></span>
 ## You can request one domain per online service
 
 For non-federal agencies, we generally approve one domain per online service per government organization. We'll evaluate additional requests on a case-by-case basis.


### PR DESCRIPTION
Added an ID tag to a heading we want to use in a rejection email. The previous version of the link is very long and yucky.

[Preview the new anchor link](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/get.gov/improve-link-for-email/domains/before/#one-domain-per-service)