### PR TITLE
Updated text to reflect "Add domain manager" button

### DIFF
--- a/pages/help/help_domain-management.md
+++ b/pages/help/help_domain-management.md
@@ -34,7 +34,7 @@ Domain managers can update all information related to a domain within the .gov r
 3. Click “Domain managers” on the left-side navigation.
 4. Click “Add a domain manager” in the "Domain managers" section.
 5. Enter the email address for the person you want to add as a domain manager. 
-6. Click “Add user.”
+6. Click “Add domain manager.”
 7. An email invitation will be sent to that person with instructions on how to set up an account.
 
 All domain managers must  keep their contact information updated and be responsive if contacted by the .gov team.


### PR DESCRIPTION
The text in the app is now "Add a domain manager." In the next release it will be "Add domain manager."

(History: The text in the app was "Add user." I should have changed it to "Add domain manager" instead of "Add a domain manager" in the first place. Note that this text appears when a user has added an email for the person they want to add.)