### PR TITLE
Add more descriptive descriptions for landing pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: layouts/wide
 title: Home
+excerpt: .Gov is the top-level domain for governments in the U.S. Request and manage a .gov domain.
 pagination:
   data: collections.posts
   size: 8

--- a/pages/about/about_index.md
+++ b/pages/about/about_index.md
@@ -3,7 +3,7 @@ title: About the .gov registry
 permalink: /about/
 layout: layouts/info-page
 sidenav: true
-excerpt: Learn about the .gov registry
+excerpt: Learn about the .gov registry, registrar, job openings, product updates, and more.
 tags: about
 eleventyNavigation:
   key: about

--- a/pages/about/about_index.md
+++ b/pages/about/about_index.md
@@ -3,7 +3,7 @@ title: About the .gov registry
 permalink: /about/
 layout: layouts/info-page
 sidenav: true
-excerpt: Learn about the .gov registry, registrar, job openings, product updates, and more.
+excerpt: Learn about the .gov registry, registrar, .gov data, job openings, product updates, and more.
 tags: about
 eleventyNavigation:
   key: about

--- a/pages/blog/blog_index.md
+++ b/pages/blog/blog_index.md
@@ -3,7 +3,7 @@ layout: layouts/blog
 title: Blog
 subtitle: What's happening around .gov 
 permalink: "/blog/{%if pagination.pageNumber > 0 %}{{pagination.pageNumber | plus:1 }}/{% endif %}"
-excerpt: What's happening around .gov
+excerpt: Blog posts from the .gov team
 pagination:
   data: collections.posts
   size: 8

--- a/pages/domains/domains_index.md
+++ b/pages/domains/domains_index.md
@@ -1,5 +1,5 @@
 ---
-title: Learn about .gov domains
+title: .Gov domains
 permalink: /domains/
 layout: layouts/landing
 excerpt: Find out if you're eligible for a .gov domain. Learn how to get a .gov domain. Get tips for moving to .gov from another top-level domain.

--- a/pages/domains/domains_index.md
+++ b/pages/domains/domains_index.md
@@ -1,8 +1,8 @@
 ---
-title: Domains
+title: Learn about .gov domains
 permalink: /domains/
 layout: layouts/landing
-excerpt: Learn about .gov domains
+excerpt: Find out if you're eligible for a .gov domain. Learn how to get a .gov domain. Get tips for moving to .gov from another top-level domain.
 sidenav: true
 outlined_links: true
 tags: domains


### PR DESCRIPTION
Add more descriptive descriptions for landing pages. When these descriptions go into product we can verify whether or not they improve the display of get.gov pages on Google. 

New descriptions for:

- Home page
- About
- Blog 
- Domains