### PR TITLE
Hide nav links to job pages

### DIFF
--- a/pages/about/about_index.md
+++ b/pages/about/about_index.md
@@ -16,7 +16,7 @@ eleventyNavigation:
 
 We are the .gov registry. We're a team of designers, developers, and product people. We help government organizations in the U.S. gain public trust by making .gov a well-known, reliable, and secure space online. The .gov registry is part of the [Cybersecurity and Infrastructure Security Agency](https://www.cisa.gov/). 
 
-Check out [job openings on our team](jobs).
+<!-- Check out [job openings on our team](jobs). -->
 
 ## What we do
 

--- a/pages/about/jobs.md
+++ b/pages/about/jobs.md
@@ -5,10 +5,12 @@ layout: layouts/info-page
 sidenav: true
 excerpt: Work with the .gov team
 tags: about
-eleventyNavigation:
+<!-- Commenting out while we have no open jobs
+  eleventyNavigation:
   key: jobs
   order: 3
   title: .Gov jobs
+  -->
 ---
   
 We are the .gov registry at the Cybersecurity and Infrastructure Security Agency (CISA). We're a team of designers, developers, and product people. We help government organizations in the U.S. gain public trust by making .gov a well-known, reliable, and secure space online.

--- a/pages/about/jobs.md
+++ b/pages/about/jobs.md
@@ -5,12 +5,6 @@ layout: layouts/info-page
 sidenav: true
 excerpt: Work with the .gov team
 tags: about
-<!-- Commenting out while we have no open jobs
-  eleventyNavigation:
-  key: jobs
-  order: 3
-  title: .Gov jobs
-  -->
 ---
   
 We are the .gov registry at the Cybersecurity and Infrastructure Security Agency (CISA). We're a team of designers, developers, and product people. We help government organizations in the U.S. gain public trust by making .gov a well-known, reliable, and secure space online.


### PR DESCRIPTION
Removed subnav front matter to hide job pages (because we have no open positions)

Removed:
```
eleventyNavigation:
  key: jobs
  order: 3
  title: .Gov jobs
```