### PR TITLE
Update featured-dotgov.html March 2024

### DIFF
--- a/_includes/featured-dotgov.html
+++ b/_includes/featured-dotgov.html
@@ -9,9 +9,9 @@
       </h2>
   <div class="usa-summary-box__text">
     <h4 class="font-heading-lg text-semibold margin-top-205 margin-bottom-205">
-      <a class="usa-link usa-link--external" rel="noopener noreferrer" href="https://blackhistorymonth.gov/">BlackHistoryMonth.gov</a>
+      <a class="usa-link usa-link--external" rel="noopener noreferrer" href="https://read.gov/">Read.gov</a>
     </h4>
-    <p>A collaboration between the Library of Congress and other federal agencies recognizing the unique history, experiences, and contributions of Black Americans.</p>
+    <p>Managed by the Library of Congress, Read.gov invites all people to discover the fascinating ideas, places, and events that await you within each book.</p>
     <p><a class="usa-link" href="{{ '/about/data' | url }}">Explore .gov data</a></p>  
   </div>
     </div>


### PR DESCRIPTION
Updated for National Reading Month as we coordinate with other potential featured domains.

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated featured .gov from BlackHistoryMonth.gov to Read.gov

## Context for reviewers

<!--Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.  --> Still need to coordinate with henryvilaszoo.gov which was planned to be the March featured domain. Once we do coordinate, Read.gov will be replace. This change should match the details present in the [Featured .gov](https://docs.google.com/document/d/1jkiWrB1YCdhTD85xWDzJhg3gb0Sk_HnXYg-2SjGeDko/edit) document for Read.gov.
