### PR TITLE
Update help_identity-error.md to request no attachments

### DIFF
--- a/pages/help/help_identity-error.md
+++ b/pages/help/help_identity-error.md
@@ -9,11 +9,11 @@ We use Login.gov to verify you are who you say you are. Unfortunately, we’re u
 
 If you’d still like to proceed with requesting a .gov domain, email <help@get.gov> from your work email address with the following information:
 
-- The name of the government organization you represent
-- The .gov domain name you think you'll request
-- Your organization’s physical address
-- Your organization’s website
-- Your first and last name
-- Your title
+- The name of the government organization you represent: 
+- The .gov domain name you think you'll request: 
+- Your organization’s physical address: 
+- Your organization’s website: 
+- Your first and last name: 
+- Your title: 
 
-Use the subject line: “Unable to verify with Login.gov: NAME OF YOUR ORGANIZATION.”
+Use the subject line: “Unable to verify with Login.gov: NAME OF YOUR ORGANIZATION”, using the name of your organization.  Do not send attachments of your ID or share other sensitive information.


### PR DESCRIPTION
When users cannot verify with Login.gov, they hit the identity-error page. Some are using the variable in the subject line straight, and others are including attachments of sensitive documents. Neither are helpful.

This small update adds more words in an attempt to clarify what we are/aren't asking.