### PR TITLE
Add "plan ahead" content to get.gov

### DIFF
--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -11,12 +11,9 @@ eleventyNavigation:
   title: Before you request a .gov domain
 ---
 
-You must be a government employee, or be working on behalf of the government, to request a .gov domain. 
-
-If you’re ready to request your domain then let’s get started. You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready. 
-
-{% modal-trigger--button %}
-{% modal-body %}
+To request a .gov domain, you must be a government employee—or be working on behalf of the government—in a technological, administrative, or executive capacity. Requests from officials in a senior role (e.g., a CIO, a city manager) may be processed faster.
+ 
+If you have important deadlines to meet, plan ahead and start the request process as soon as possible. It may take several weeks for your request to be evaluated. The guidance below is meant to help you understand the process and navigate it efficiently. 
 
 ## Purpose of the domain request form
 
@@ -113,5 +110,14 @@ After your domain is approved, we’ll ask you to provide the following informat
 - Security email for public use
 
 Before your approved .gov domain can be used, you’ll need to connect it to your DNS hosting service. **At this time, we don’t provide DNS hosting services.**
- 
+
 Read more about [domain management.](../../help/domain-management/)
+
+
+## Start your domain request
+
+If you’re ready to request your domain, then let’s get started. You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready. 
+
+{% modal-trigger--button %}
+{% modal-body %}
+ 

--- a/pages/domains/domains_moving.md
+++ b/pages/domains/domains_moving.md
@@ -19,6 +19,7 @@ Organizations at all levels of government (federal, state, local) are eligible f
 ## Checklist for moving to .gov
 
 Read more about each of these steps below.{.checklist}
+- [Be proactive and start the process early](#be-proactive-and-start-the-process-early)
 - [Start the conversation with your technical and communications staff](#start-the-conversation-with-your-technical-and-communications-staff)
 - [Come up with .gov domain options that meet our naming requirements](#come-up-with-.gov-domain-options-that-meet-our-naming-requirements)
 - [Get ready to complete the .gov domain request form](#get-ready-to-complete-the-.gov-domain-request-form)
@@ -34,10 +35,16 @@ Read more about each of these steps below.{.checklist}
 - [Let us know how it goes](#let-us-know-how-it-goes)
 
 
+## Be proactive and start the process early
+
+Getting a .gov domain is different from purchasing a .com or .org address. That's because we conduct a review on each domain request, and these take time. We don't operate on a first-come, first-served basis.
+
+If you have important deadlines to meet, plan ahead when moving to a .gov domain. We’ll need to review your domain request, and that can take 30 business days. Due to the volume of requests, the wait time for completing our review is longer than usual.
+
+
 ## Start the conversation with your technical and communications staff
 
 Identify who you’ll work with from your IT team (e.g., folks responsible for DNS, web, network, information security), public affairs (people responsible for public communication online, in print, or elsewhere), and administrative staff. Think about the internal approvals you’ll need for a new .gov domain.
-
 
 
 ## Come up with .gov domain options that meet our naming requirements
@@ -47,6 +54,7 @@ We’ll try to give you your preferred domain. We’ll make sure your request me
 {% include 'content-blocks/general_domain_requirements.md' %}
 
 [Read more about our domain name requirements](../choosing/).
+
 
 ## Get ready to complete the .gov domain request form
 


### PR DESCRIPTION
## Ticket

Resolves #[1847](https://github.com/cisagov/manage.get.gov/issues/1847)

**Changes**
Added language to the following pages encouraging registrants to plan ahead and request their domain long before they may want to use it.
- ["Moving to .gov" page](https://docs.google.com/document/d/1EL6pBxmLGMj3_b726H2Ai4yY3N7ukufW1Vu3cdTwE8M/edit#heading=h.lb3crsch0fj9).
- ["Before you request" page](https://docs.google.com/document/d/1PIJ_7JGoTIZkV4BrSBiZX7f8mpWsAY4UMaqHMn61dzQ/edit#heading=h.gjdgxs).