### PR TITLE
Add election/feds to delay banner

### DIFF
--- a/_includes/banner-info.html
+++ b/_includes/banner-info.html
@@ -6,7 +6,7 @@
           Our review is taking longer than normal
         </h3>
         <p class="usa-alert__text">
-          Due to high volume, the review process for new domain requests may take 8 weeks or more. <a href="https://manage.get.gov" target="_blank">Sign in</a> to check the status of your request. 
+          Due to high volume, the review process for new domain requests may take 8 weeks or more. We’ll prioritize requests from election organizations and federal agencies. <a href="https://manage.get.gov" target="_blank">Sign in</a> to check the status of your request. 
         </p>
       </div>
     </div>


### PR DESCRIPTION
This change alerts people on get.gov that we'll prioritize requests from election orgs and federal agencies. 