### PR TITLE
Remove "8 weeks" banner and add more detail to /about/product

### DIFF
--- a/_includes/banner-info.html
+++ b/_includes/banner-info.html
@@ -3,10 +3,10 @@
     <div class="usa-alert">
       <div class="usa-alert__body">
         <h3 class="usa-alert__heading text-black">
-          Our review is taking longer than normal
+          Header here
         </h3>
         <p class="usa-alert__text">
-          Due to high volume, the review process for new domain requests may take 8 weeks or more. We’ll prioritize requests from election organizations and federal agencies. <a href="https://manage.get.gov" target="_blank">Sign in</a> to check the status of your request. 
+          Text here 
         </p>
       </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@ official government website
   <!-- NOTE: Edit the date/time on the banner before posting -->
   <!-- {% include "banner-system-outage.html" %} -->
   <!-- {% include "banner-service-disruption.html" %} -->
-  {% include "banner-info.html" %}
+  <!-- {% include "banner-info.html" %} -->
   <!-- {% include "banner-warning.html" %} -->
   <!-- {% include "banner-error.html" %} -->
   <!-- {% include "banner-site-alert.html" %} -->

--- a/pages/about/product_updates.md
+++ b/pages/about/product_updates.md
@@ -15,9 +15,9 @@ We’ll share notes about product releases and new features here.
 
 ## July 24, 2024
 
-### Tell us who you really are...
+### Your contact info, now in one place
 
-Each domain registrant is [required](https://get.gov/domains/requirements/#what-gov-domain-registrants-must-do) to maintain accurate contact information with us, but we previously kept this info on a per-domain level. That made it hard to know how to update these details, especially for those that manage multiple domains.
+Each domain registrant is [required](../../domains/requirements/#what-gov-domain-registrants-must-do) to maintain accurate contact information with us, but we previously kept this info on a per-domain level. That made it hard to know how to update these details, especially for those that manage multiple domains.
 
 We’ve centralized your contact information in a single place so you can easily let us know when something has changed. Check it out in “[Your profile](https://manage.get.gov/user-profile)”. 
 

--- a/pages/about/product_updates.md
+++ b/pages/about/product_updates.md
@@ -13,6 +13,19 @@ eleventyNavigation:
 
 We’ll share notes about product releases and new features here.
 
+## July 24, 2024
+
+### Tell us who you really are...
+
+Each domain registrant is [required](https://get.gov/domains/requirements/#what-gov-domain-registrants-must-do) to maintain accurate contact information with us, but we previously kept this info on a per-domain level. That made it hard to know how to update these details, especially for those that manage multiple domains.
+
+We’ve centralized your contact information in a single place so you can easily let us know when something has changed. Check it out in “[Your profile](https://manage.get.gov/user-profile)”. 
+
+<figure style="padding: 5px;">
+<img width="1092" legth src="https://github.com/user-attachments/assets/6673fb17-b036-4efb-b80d-70b3eab1f457" alt="image" title="A screenshot of the new profile feature" style="border: 1px solid;"/> 
+<figcaption style="font-style: italic;">A screenshot of the new profile feature</figcaption>
+</figure>
+
 ## January 31, 2024
 
 Today we launched a new way to get a .gov domain. You’re reading this on our new [get.gov](https://get.gov) site. The purpose of this site is to help eligible government organizations get and manage .gov domains.


### PR DESCRIPTION
We're caught up and don't need to highlight any delays, so let's remove the info banner.

This also closes #318, adding some detail to our /about/product page.