### PR TITLE
Spring cleaning on get.gov

### DIFF
--- a/pages/about/data.md
+++ b/pages/about/data.md
@@ -1,5 +1,5 @@
 ---
-title: .Gov data
+title: Data
 permalink: /about/data/
 layout: layouts/info-page
 sidenav: true
@@ -8,7 +8,7 @@ tags: about
 eleventyNavigation:
   key: about
   order: 2
-  title: .Gov data
+  title: Data
 ---
   
 

--- a/pages/about/product_updates.md
+++ b/pages/about/product_updates.md
@@ -1,5 +1,5 @@
 ---
-title: .Gov product updates
+title: Product updates
 permalink: /about/product/
 layout: layouts/info-page
 sidenav: true
@@ -8,7 +8,7 @@ tags: about
 eleventyNavigation:
   key: about
   order: 6
-  title: .Gov product updates
+  title: Product updates
 ---  
 
 We’ll share notes about product releases and new features here.

--- a/pages/domains/domains_eligibility.md
+++ b/pages/domains/domains_eligibility.md
@@ -52,7 +52,7 @@ When you request a .gov domain, we’ll ask for information about your senior of
 ### Executive branch federal agencies {.h4}
 Domain requests from executive branch federal agencies must be authorized by the agency’s CIO or the head of the agency.
 
-See [OMB Memorandum M-23-10](https://bidenwhitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf){.usa-link--external} for more information.
+See [OMB Memorandum M-23-10](https://whitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf){.usa-link--external} for more information.
 
 ### Judicial branch federal agencies {.h4}
 Domain requests for judicial branch federal agencies, except the U.S. Supreme Court, must be authorized by the director or CIO of the Administrative Office (AO) of the United States Courts.

--- a/pages/domains/domains_eligibility.md
+++ b/pages/domains/domains_eligibility.md
@@ -100,7 +100,7 @@ Domain requests from special districts must be authorized by someone in a role o
 ### School districts {.h4}
 Domain requests from school district governments must be authorized by someone in a role of significant, executive responsibility within the district (board chair, superintendent, senior technology officer, or equivalent).
 
-We use the [U.S. Census Bureau's definition of school district governments](https://www.census.gov/library/publications/2019/econ/2017isd.html){.usa-link--external}.
+We use the [U.S. Census Bureau's definition of school district governments](https://www.census.gov/library/publications/2024/econ/2022isd.html){.usa-link--external}.
 
 ## Request your .gov domain
 

--- a/pages/domains/domains_executive-branch-guidance.md
+++ b/pages/domains/domains_executive-branch-guidance.md
@@ -13,7 +13,7 @@ eleventyNavigation:
 
 ## Submitting domain requests
 
-Federal executive branch agency requests for new .gov domains will be reviewed by the Office of Management and Budget (OMB) as required by M-23-10, [The Registration and Use of .gov Domains in the Federal Government](https://bidenwhitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf){.usa-link--external}.
+Federal executive branch agency requests for new .gov domains will be reviewed by the Office of Management and Budget (OMB) as required by M-23-10, [The Registration and Use of .gov Domains in the Federal Government](https://whitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf){.usa-link--external}.
 
 When submitting a request, you must describe:
 
@@ -149,4 +149,4 @@ Agencies may not use a .gov domain name:
 
 ### Compliance with the 21st Century IDEA is required {.h4}
 
-As required by the DOTGOV Act, agencies must ensure that any website or digital service that uses a .gov domain name is in compliance with the [21st Century Integrated Digital Experience Act](https://digital.gov/resources/delivering-digital-first-public-experience/){.usa-link--external} and [implementation guidance](https://bidenwhitehouse.gov/wp-content/uploads/2023/09/M-23-22-Delivering-a-Digital-First-Public-Experience.pdf){.usa-link--external}.
+As required by the DOTGOV Act, agencies must ensure that any website or digital service that uses a .gov domain name is in compliance with the [21st Century Integrated Digital Experience Act](https://digital.gov/resources/delivering-digital-first-public-experience/){.usa-link--external} and [implementation guidance](https://whitehouse.gov/wp-content/uploads/2023/09/M-23-22-Delivering-a-Digital-First-Public-Experience.pdf){.usa-link--external}.

--- a/pages/domains/domains_security.md
+++ b/pages/domains/domains_security.md
@@ -46,7 +46,7 @@ All newly registered .gov domains are “preloaded,” or added to the [HSTS pre
 
 After a domain is on the preload list, modern web browsers will enforce HTTPS connections for all websites on the domain. 
 
-We intend to preload the .gov top-level domain. In the meantime, we recommend preloading .gov domains that haven’t yet been (a required action for federal agencies under the [Federal Zero Trust Strategy](https://bidenwhitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf#page=14){.usa-link--external}).
+We intend to preload the .gov top-level domain. In the meantime, we recommend preloading .gov domains that haven’t yet been (a required action for federal agencies under the [Federal Zero Trust Strategy](https://whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf#page=14){.usa-link--external}).
 
 [Read our blog post about preloading](../../posts/2021-06-21-an-intent-to-preload/).
 

--- a/pages/help/help_faq.md
+++ b/pages/help/help_faq.md
@@ -12,7 +12,7 @@ eleventyNavigation:
 **Domain requests**
 - [How much does a .gov domain cost?](#gov-domains-are-free)
 - [I'm working with a government organization. Why do I have to provide personal information to request a domain on their behalf?](#working-with-a-gov-org)
-- [Can I request a name like cityname.state.gov (e.g., detroit.mi.gov?)](#subdomain)
+- [Can I request a name like cityname.state.gov (e.g., detroit.mi.gov)?](#subdomain)
 - [How much longer until I hear back about a domain request?](#domain-request-status)
 
 Get more [help with domain requests](../domain-requests).

--- a/pages/help/help_faq.md
+++ b/pages/help/help_faq.md
@@ -10,30 +10,30 @@ eleventyNavigation:
 ---
 
 **Domain requests**
-- [How much does a .gov domain cost](#gov-domains-are-free)?
-- [I'm working with a government organization. Why do I have to provide personal information to request a domain on their behalf](#working-with-a-gov-org)?
-- [Can I request a name like cityname.state.gov (e.g., detroit.mi.gov)](#subdomain)?
-- [How much longer until I hear back about a domain request](#domain-request-status)?
+- [How much does a .gov domain cost?](#gov-domains-are-free)
+- [I'm working with a government organization. Why do I have to provide personal information to request a domain on their behalf?](#working-with-a-gov-org)
+- [Can I request a name like cityname.state.gov (e.g., detroit.mi.gov?)](#subdomain)
+- [How much longer until I hear back about a domain request?](#domain-request-status)
 
 Get more [help with domain requests](../domain-requests).
 
 <p class="border-bottom": 1px solid> </p>
 
 **Domain management**
-- [How do I add or remove someone from a domain](#add-or-remove-from-domain)?
-- [Why don't I see a domain when I sign in to the registrar](#do-not-see-my-domain)?
-- [A domain will expire soon. How can I renew it?](#renew-domain)?
-- [What happens if I don’t renew a domain](#dont-renew)?
-- [Where can I add DNS records](#dns-records)?
-- [My DNS hosting provider wants me to transfer my .gov domain to their registrar. What should I do](#transfer-domain)?
-- [Where do I get a .gov email address](#email-address)?
+- [How do I add or remove someone from a domain?](#add-or-remove-from-domain)
+- [Why don't I see a domain when I sign in to the registrar?](#do-not-see-my-domain)
+- [A domain will expire soon. How can I renew it?](#renew-domain)
+- [What happens if I don’t renew a domain?](#dont-renew)
+- [Where can I add DNS records?](#dns-records)
+- [My DNS hosting provider wants me to transfer my .gov domain to their registrar. What should I do?](#transfer-domain)
+- [Where do I get a .gov email address?](#email-address)
 
 Get more [help with domain management](../domain-management).
 
 <p class="border-bottom": 1px solid> </p>
 
 **Domain requirements**
-- [Your policies prohibit using a .gov domain for “commercial purposes." What does that mean](#commercial-purposes)?
+- [Your policies prohibit using a .gov domain for “commercial purposes." What does that mean?](#commercial-purposes)
 
 <p class="border-bottom": 1px solid> </p>
 

--- a/posts/2022-09-14-making-infrastructure-less-invisible.md
+++ b/posts/2022-09-14-making-infrastructure-less-invisible.md
@@ -53,13 +53,13 @@ If you have ideas on how the document can be improved, we’d welcome suggestion
 
 ## Ending support for fed.us
 
-In times past, some federal agencies used a domain name under the [fed.us locality space](https://www.about.us/policies/ustld-locality-based-structure){.usa-link--external}. Registrations in fed.us [formally ended in 2017](https://bidenwhitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf#page=11){.usa-link--external}, and in early 2022 there were only five remaining domains.
+In times past, some federal agencies used a domain name under the [fed.us locality space](https://www.about.us/policies/ustld-locality-based-structure){.usa-link--external}. Registrations in fed.us [formally ended in 2017](https://whitehouse.gov/wp-content/uploads/legacy_drupal_files/omb/memoranda/2017/m-17-06.pdf#page=11){.usa-link--external}, and in early 2022 there were only five remaining domains.
 
 In order to prioritize our resources on .gov, we will stop resolution of the fed.us zone in mid-October 2022.
 
 ## Collecting non-.gov domains
 
-Under the [Federal Zero Trust Strategy](https://bidenwhitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf#page=19){.usa-link--external}, we’re working with partners at the General Services Administration to collect the non-.gov domains that federal agencies use. If you see any that should be added to the list, report them at [https://search.gov/about/policy/govt-urls.html](https://search.gov/about/policy/govt-urls.html){.usa-link--external}.
+Under the [Federal Zero Trust Strategy](https://whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf#page=19){.usa-link--external}, we’re working with partners at the General Services Administration to collect the non-.gov domains that federal agencies use. If you see any that should be added to the list, report them at [https://search.gov/about/policy/govt-urls.html](https://search.gov/about/policy/govt-urls.html){.usa-link--external}.
 
 ## Making it harder to impersonate U.S.-based governments
 

--- a/posts/2023-02-08-OMB-new-requirements-for-federal-executive-agencies.md
+++ b/posts/2023-02-08-OMB-new-requirements-for-federal-executive-agencies.md
@@ -20,4 +20,4 @@ Requirements include:
 
 OMB reviews domain requests to ensure that agencies are following relevant policies and domain name requirements, to help avert or resolve potential domain-naming conflicts between agencies, and to reduce confusion arising from overuse of similar domain names and misalignment between a domain name and its intended use. In areas of domain name conflict, OMB will seek resolution with the agencies involved. OMB may deny a domain name request or a domain name renewal, or may request that an agency transfer ownership of an existing domain to another agency to remediate potential conflict or confusion. 
 
-Read the full [OMB Memorandum 23-10](https://bidenwhitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf){.usa-link--external}.
+Read the full [OMB Memorandum 23-10](https://whitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf){.usa-link--external}.


### PR DESCRIPTION
This PR folds several small changes together. It
* Fixes a double question-mark that turned into moving all the question marks inside the link
* Updated wh.gov links, now the M memos are back up
* Changing the headers on the /about page to remove ".gov"