### PR TITLE
Remove contact form from /contact

### DIFF
--- a/pages/contact.md
+++ b/pages/contact.md
@@ -10,9 +10,7 @@ eleventyNavigation:
   
 Have a question? Visit [our FAQ page for answers to common questions about .gov domains](../help/faq). 
 
-If you don't find an answer, send us a message by completing the form below.
-
-<iframe width="640px" height="700px" src="https://forms.office.com/Pages/ResponsePage.aspx?id=bOfNPG2UEkq7evydCEI1SseS7Uruj0hGoPWlATpAlzVUOFpaTkxSSkNSNlRKVFFFMEJMOVc1S1hJRS4u&embed=true" title="Contact the .gov team" frameborder="0" marginwidth="0" marginheight="0" style="border: none; max-width:100%; max-height:100vh" allowfullscreen webkitallowfullscreen mozallowfullscreen msallowfullscreen> </iframe>
+If you don't find an answer, email us at <help@get.gov>.
 
 ## Visit us on GitHub
 


### PR DESCRIPTION
Out contact form is having issues. This PR drops it and adds an email address.